### PR TITLE
Modified pack-scan report columns, added support for older RHEL dmidecode

### DIFF
--- a/src/rho/clicommands.py
+++ b/src/rho/clicommands.py
@@ -361,7 +361,12 @@ class InitConfigCommand(CliCommand):
                                         'redhat-packages.last_built',
                                         'virt-what.type', 'virt.virt',
                                         'virt.num_guests', 'virt.num_running_guests',
-                                        'cpu.count', 'cpu.socket_count', 'ip', 'port']),
+                                        'cpu.count', 'cpu.socket_count', 'ip', 'port',
+                                        'auth.name', 'auth.type', 'auth.username', 'error',
+                                        'dmi.system-manufacturer', 'etc-release.etc-release',
+                                        'instnum.instnum', 'redhat-release.version',
+                                        'subman.virt.host_type', 'systemid.system_id',
+                                        'subman.virt.is_guest', 'uname.hardware_platform']),
         ]
         new_config = config.Config(auths=auths, profiles=profiles, reports=reports)
         print (_("Creating new config with defaults: %s") % self.options.config)


### PR DESCRIPTION
- Added additional columns to the pack-scan report generated by the initconfig command. The current pack-scan format does not include error, auth.name, and auth.username fields that are helpful when troubleshooting. The other fields are added to get additional visibility into all fields Rho can collect.

- replaced some key dmidecode commands that used switches not available on older versions of RHEL with commands that work on all versions of RHEL.

- added check for QEMU in manufacturer name to determine virt.type and virt.virt.
