### PR TITLE
Added 4 date commands to help determine when a server was built.

### DIFF
--- a/src/rho/clicommands.py
+++ b/src/rho/clicommands.py
@@ -359,6 +359,8 @@ class InitConfigCommand(CliCommand):
                                         'redhat-packages.num_installed_packages',
                                         'redhat-packages.last_installed',
                                         'redhat-packages.last_built',
+                                        'date.anaconda_log', 'date.machine_id',
+                                        'date.filesystem_create', 'date.yum_history',
                                         'virt-what.type', 'virt.virt',
                                         'virt.num_guests', 'virt.num_running_guests',
                                         'cpu.count', 'cpu.socket_count', 'ip', 'port',

--- a/src/rho/rho_cmds.py
+++ b/src/rho/rho_cmds.py
@@ -72,14 +72,27 @@ class RhoCmd(object):
 
 class DateRhoCmd(RhoCmd):
     name = "date"
-    cmd_strings = ['date']
+    cmd_strings = ['date',
+                   "ls --full-time /root/anaconda-ks.cfg | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'",
+                   "ls --full-time /etc/machine-id | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'",
+                   "fs_date=$(tune2fs -l $(mount | egrep '/ type' | grep -o '/dev.* on' "
+                   "| sed -e 's/\on//g') | grep 'Filesystem created' | sed 's/Filesystem created:\s*//g'); "
+                   "if [[ $fs_date ]]; then date +'%F' -d \"$fs_date\"; else echo "" ; fi",
+                   "yum history | tail -n 4 | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'"]
 
-    fields = {'date.date': _('date')}
+    fields = {'date.date': _('date'),
+              'date.anaconda_log': _("/root/anaconda-ks.cfg modified time"),
+              'date.machine_id': _("/etc/machine-id modified time'"),
+              'date.filesystem_create': _("uses tune2fs -l on the / filesystem dev found using mount"),
+              'date.yum_history': _("dates from yum history")}
 
     def parse_data(self):
 
         self.data['date.date'] = self.cmd_results[0][0].strip()
-
+        self.data['date.anaconda_log'] = self.cmd_results[1][0].strip()
+        self.data['date.machine_id'] = self.cmd_results[2][0].strip()
+        self.data['date.filesystem_create'] = self.cmd_results[3][0].strip()
+        self.data['date.yum_history'] = self.cmd_results[4][0].strip()
 
 class UnameRhoCmd(RhoCmd):
     name = "uname"


### PR DESCRIPTION
- date.anaconda_log - looks at the /root/anaconda-ks.cfg file
- date.machine_id - looks at the /etc/machine-id file (only on rhel 7+)
- date.filesystem_create- looks at the filesystem creation date (only for ext)
- date.yum_history - looks at the yum transaction history